### PR TITLE
Improve apkeep output

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,7 +19,8 @@ pub fn app() -> App<'static, 'static> {
                 .help("Provide the ID of an app directly (e.g. com.instagram.android)")
                 .short("a")
                 .long("app-id")
-                .takes_value(true))
+                .takes_value(true),
+        )
         .arg(
             Arg::with_name("csv")
                 .help("CSV file to use")
@@ -27,14 +28,16 @@ pub fn app() -> App<'static, 'static> {
                 .long("csv")
                 .takes_value(true)
                 .conflicts_with("app_id")
-                .required_unless("app_id"))
+                .required_unless("app_id"),
+        )
         .arg(
             Arg::with_name("field")
                 .help("CSV field containing app IDs (used only if CSV is specified)")
                 .short("f")
                 .long("field")
                 .takes_value(true)
-                .default_value("1"))
+                .default_value("1"),
+        )
         .arg(
             Arg::with_name("download_source")
                 .help("Where to download the APKs from")
@@ -43,28 +46,32 @@ pub fn app() -> App<'static, 'static> {
                 .default_value("APKPure")
                 .takes_value(true)
                 .possible_values(&DownloadSource::variants())
-                .required(false))
+                .required(false),
+        )
         .arg(
             Arg::with_name("google_username")
                 .help("Google Username (required if download source is Google Play)")
                 .short("u")
                 .long("username")
                 .takes_value(true)
-                .required_if("download_source", "GooglePlay"))
+                .required_if("download_source", "GooglePlay"),
+        )
         .arg(
             Arg::with_name("google_password")
                 .help("Google App Password (required if download source is Google Play)")
                 .short("p")
                 .long("password")
                 .takes_value(true)
-                .required_if("download_source", "GooglePlay"))
+                .required_if("download_source", "GooglePlay"),
+        )
         .arg(
             Arg::with_name("sleep_duration")
                 .help("Sleep duration (in ms) before download requests")
                 .short("s")
                 .long("sleep-duration")
                 .takes_value(true)
-                .default_value("0"))
+                .default_value("0"),
+        )
         .arg(
             Arg::with_name("parallel")
                 .help("The number of parallel APK fetches to run at a time")
@@ -72,9 +79,12 @@ pub fn app() -> App<'static, 'static> {
                 .long("parallel")
                 .takes_value(true)
                 .default_value("4")
-                .required(false))
-        .arg(Arg::with_name("OUTPATH")
-            .help("Path to store output files")
-            .required(true)
-            .index(1))
+                .required(false),
+        )
+        .arg(
+            Arg::with_name("OUTPATH")
+                .help("Path to store output files")
+                .required(true)
+                .index(1),
+        )
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,10 +106,10 @@ async fn download_apps_from_google_play(
                 match gpa.download(&app_id, None, &Path::new(outpath)).await {
                     Ok(_) => println!("{} downloaded successfully!", app_id),
                     Err(err) if matches!(err.kind(), GpapiErrorKind::FileExists) => {
-                        println!("File already exists for {}.  Aborting.", app_id);
+                        println!("File already exists for {}. Skipping...", app_id);
                     }
                     Err(err) if matches!(err.kind(), GpapiErrorKind::InvalidApp) => {
-                        println!("Invalid app response for {}.  Aborting.", app_id);
+                        println!("Invalid app response for {}. Skipping...", app_id);
                     }
                     Err(_) => {
                         println!("An error has occurred attempting to download {}.  Retry #1...", app_id);
@@ -120,7 +120,7 @@ async fn download_apps_from_google_play(
                                 match gpa.download(&app_id, None, &Path::new(outpath)).await {
                                     Ok(_) => println!("{} downloaded successfully!", app_id),
                                     Err(_) => {
-                                        println!("An error has occurred attempting to download {}.  Aborting.", app_id);
+                                        println!("An error has occurred attempting to download {}. Skipping...", app_id);
                                     }
                                 }
                             }
@@ -174,7 +174,7 @@ async fn download_apps_from_apkpure(
                                 match tokio_dl_stream_to_disk::download(download_url, &Path::new(outpath), &fname).await {
                                     Ok(_) => println!("{} downloaded successfully!", app_id),
                                     Err(err) if matches!(err.kind(), TDSTDErrorKind::FileExists) => {
-                                        println!("File already exists for {}.  Aborting.", app_id);
+                                        println!("File already exists for {}. Skipping...", app_id);
                                     },
                                     Err(_) => {
                                         println!("An error has occurred attempting to download {}.  Retry #1...", app_id);
@@ -185,7 +185,7 @@ async fn download_apps_from_apkpure(
                                                 match tokio_dl_stream_to_disk::download(download_url, &Path::new(outpath), &fname).await {
                                                     Ok(_) => println!("{} downloaded successfully!", app_id),
                                                     Err(_) => {
-                                                        println!("An error has occurred attempting to download {}.  Aborting.", app_id);
+                                                        println!("An error has occurred attempting to download {}. Skipping...", app_id);
                                                     }
                                                 }
                                             }
@@ -194,12 +194,12 @@ async fn download_apps_from_apkpure(
                                 }
                             },
                             _ => {
-                                println!("Could not get download URL for {}.  Aborting.", app_id);
+                                println!("Could not get download URL for {}. Skipping...", app_id);
                             }
                         }
                     },
                     _ => {
-                        println!("Invalid app response for {}.  Aborting.", app_id);
+                        println!("Invalid app response for {}. Skipping...", app_id);
                     }
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,7 +94,7 @@ async fn download_apps_from_google_play(app_ids: Vec<String>, parallel: usize, s
                     sleep(TokioDuration::from_millis(sleep_duration)).await;
                 }
                 match gpa.download(&app_id, None, &Path::new(outpath)).await {
-                    Ok(_) => (),
+                    Ok(_) => println!("{} downloaded successfully!", app_id),
                     Err(err) if matches!(err.kind(), GpapiErrorKind::FileExists) => {
                         println!("File already exists for {}.  Aborting.", app_id);
                     }
@@ -104,11 +104,11 @@ async fn download_apps_from_google_play(app_ids: Vec<String>, parallel: usize, s
                     Err(_) => {
                         println!("An error has occurred attempting to download {}.  Retry #1...", app_id);
                         match gpa.download(&app_id, None, &Path::new(outpath)).await {
-                            Ok(_) => (),
+                            Ok(_) => println!("{} downloaded successfully!", app_id),
                             Err(_) => {
                                 println!("An error has occurred attempting to download {}.  Retry #2...", app_id);
                                 match gpa.download(&app_id, None, &Path::new(outpath)).await {
-                                    Ok(_) => (),
+                                    Ok(_) => println!("{} downloaded successfully!", app_id),
                                     Err(_) => {
                                         println!("An error has occurred attempting to download {}.  Aborting.", app_id);
                                     }
@@ -162,18 +162,18 @@ async fn download_apps_from_apkpure(app_ids: Vec<String>, parallel: usize, sleep
                                 let download_url = caps.get(1).unwrap().as_str();
                                 let fname = format!("{}.apk", app_id);
                                 match tokio_dl_stream_to_disk::download(download_url, &Path::new(outpath), &fname).await {
-                                    Ok(_) => (),
+                                    Ok(_) => println!("{} downloaded successfully!", app_id),
                                     Err(err) if matches!(err.kind(), TDSTDErrorKind::FileExists) => {
                                         println!("File already exists for {}.  Aborting.", app_id);
                                     },
                                     Err(_) => {
                                         println!("An error has occurred attempting to download {}.  Retry #1...", app_id);
                                         match tokio_dl_stream_to_disk::download(download_url, &Path::new(outpath), &fname).await {
-                                            Ok(_) => (),
+                                            Ok(_) => println!("{} downloaded successfully!", app_id),
                                             Err(_) => {
                                                 println!("An error has occurred attempting to download {}.  Retry #2...", app_id);
                                                 match tokio_dl_stream_to_disk::download(download_url, &Path::new(outpath), &fname).await {
-                                                    Ok(_) => (),
+                                                    Ok(_) => println!("{} downloaded successfully!", app_id),
                                                     Err(_) => {
                                                         println!("An error has occurred attempting to download {}.  Aborting.", app_id);
                                                     }


### PR DESCRIPTION
This pull request makes a few changes:
- Run `rustfmt` to improve code formatting
- Add a message indicating that an app was successfully downloaded.
- Replace "Aborting" with "Skipping" in error messages to indicate program flow. If a CSV is provided, the program will skip the current app and move to the next one if it errors out instead of exiting.