### PR TITLE
Add Docker images

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,0 +1,63 @@
+---
+name: docker-build-push
+
+on:
+  push:
+    branches:
+      - 'master'
+  release:
+    types:
+      - 'published'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare lowercase variable
+        run: |
+          echo IMAGE_REPOSITORY=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
+
+      - name: Build and push Docker image (development)
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_REPOSITORY }}:edge
+
+      - name: Build and push Docker image (latest + tag)
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        if: ${{ github.event_name == 'release' }}
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_REPOSITORY }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_REPOSITORY }}:${{ github.event.release.tag_name }}
+
+      - name: Build and push Docker image (stable)
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        if: ${{ github.event_name == 'release' && github.event.release.prerelease == false }}
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_REPOSITORY }}:stable

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ WORKDIR /app
 
 RUN cargo install --path .
 
-ENTRYPOINT ["apkeep", "/output"]
+ENTRYPOINT ["apkeep"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM rust:latest
+
+COPY . /app
+
+WORKDIR /app
+
+RUN cargo install --path .
+
+ENTRYPOINT ["apkeep", "/output"]

--- a/README.md
+++ b/README.md
@@ -35,65 +35,50 @@ specific release version, the following floating tags are available:
 
 See [`USAGE`](https://github.com/EFForg/apkeep/blob/master/USAGE).
 
-For the Docker image the same flags apply, except that the output path is set to /output. So
-make sure to have a volume mounted to /output.
-
 ## Examples
 
 The simplest example is to download a single APK to the current directory:
 
 ```shell
-# Local
 apkeep -a com.instagram.android .
-
-# Docker
-docker run --rm -v output_path:/output ghcr.io/efforg/apkeep:stable -a com.instagram.android
 ```
 
 This downloads from the default source, APKPure, which does not require credentials.  To
 download directly from the google play store:
 
 ```shell
-# Local
 apkeep -a com.instagram.android -d google-play -u 'someone@gmail.com' -p somepass .
-
-# Docker
-docker run --rm -v output_path:/output ghcr.io/efforg/apkeep:stable -a com.instagram.android -d google-play -u 'someone@gmail.com' -p somepass
 ```
 
 Or, to download from the F-Droid open source repository:
 
 ```shell
-# Local
 apkeep -a org.mozilla.fennec_fdroid -d f-droid .
-
-# Docker
-docker run --rm -v output_path:/output ghcr.io/efforg/apkeep:stable -a org.mozilla.fennec_fdroid -d f-droid
 ```
 
 To download a specific version of an APK (possible for APKPure or F-Droid), use the `@version`
 convention:
 
 ```shell
-# Local
 apkeep -a com.instagram.android@1.2.3 .
-
-# Docker
-docker run --rm -v output_path:/output ghcr.io/efforg/apkeep:stable -a com.instagram.android@1.2.3
 ```
 
 Or, to list what versions are available, use `-l`:
 
 ```shell
-# Local
 apkeep -l -a org.mozilla.fennec_fdroid -d f-droid
-
-# Docker
-docker run --rm ghcr.io/efforg/apkeep:stable -l -a org.mozilla.fennec_fdroid -d f-droid
 ```
 
 Refer to [`USAGE`](https://github.com/EFForg/apkeep/blob/master/USAGE) to download multiple
 APKs in a single run.
+
+All the above examples can also be used in Docker with minimal changes. For example, to
+download a single APK to your chosen output directory:
+
+```shell
+docker run --rm -v output_path:/output ghcr.io/efforg/apkeep:stable -a com.instagram.android
+/output
+```
 
 ## Specify a CSV file or individual app ID
 

--- a/README.md
+++ b/README.md
@@ -24,42 +24,72 @@ Or to install from the latest commit in our repository, run
 cargo install --git https://github.com/EFForg/apkeep.git
 ```
 
+Docker images are also available through the GitHub Container Registry. Aside from using a
+specific release version, the following floating tags are available:
+
+- stable: tracks the latest stable release (recommended)
+- latest: tracks the latest release, including pre-releases
+- edge: tracks the latest commit
+
 ## Usage
 
 See [`USAGE`](https://github.com/EFForg/apkeep/blob/master/USAGE).
+
+For the Docker image the same flags apply, except that the output path is set to /output. So
+make sure to have a volume mounted to /output.
 
 ## Examples
 
 The simplest example is to download a single APK to the current directory:
 
 ```shell
+# Local
 apkeep -a com.instagram.android .
+
+# Docker
+docker run --rm -v output_path:/output ghcr.io/efforg/apkeep:stable -a com.instagram.android
 ```
 
 This downloads from the default source, APKPure, which does not require credentials.  To
 download directly from the google play store:
 
 ```shell
+# Local
 apkeep -a com.instagram.android -d google-play -u 'someone@gmail.com' -p somepass .
+
+# Docker
+docker run --rm -v output_path:/output ghcr.io/efforg/apkeep:stable -a com.instagram.android -d google-play -u 'someone@gmail.com' -p somepass
 ```
 
 Or, to download from the F-Droid open source repository:
 
 ```shell
+# Local
 apkeep -a org.mozilla.fennec_fdroid -d f-droid .
+
+# Docker
+docker run --rm -v output_path:/output ghcr.io/efforg/apkeep:stable -a org.mozilla.fennec_fdroid -d f-droid
 ```
 
 To download a specific version of an APK (possible for APKPure or F-Droid), use the `@version`
 convention:
 
 ```shell
+# Local
 apkeep -a com.instagram.android@1.2.3 .
+
+# Docker
+docker run --rm -v output_path:/output ghcr.io/efforg/apkeep:stable -a com.instagram.android@1.2.3
 ```
 
 Or, to list what versions are available, use `-l`:
 
 ```shell
+# Local
 apkeep -l -a org.mozilla.fennec_fdroid -d f-droid
+
+# Docker
+docker run --rm ghcr.io/efforg/apkeep:stable -l -a org.mozilla.fennec_fdroid -d f-droid
 ```
 
 Refer to [`USAGE`](https://github.com/EFForg/apkeep/blob/master/USAGE) to download multiple

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,13 @@
 //! cargo install --git https://github.com/EFForg/apkeep.git
 //! ```
 //!
+//! Docker images are also available through the GitHub Container Registry. Aside from using a
+//! specific release version, the following floating tags are available:
+//!
+//! - stable: tracks the latest stable release (recommended)
+//! - latest: tracks the latest release, including pre-releases
+//! - edge: tracks the latest commit
+//!
 //! # Usage
 //!
 //! See [`USAGE`](https://github.com/EFForg/apkeep/blob/master/USAGE).
@@ -56,6 +63,14 @@
 //!
 //! Refer to [`USAGE`](https://github.com/EFForg/apkeep/blob/master/USAGE) to download multiple
 //! APKs in a single run.
+//!
+//! All the above examples can also be used in Docker with minimal changes. For example, to
+//! download a single APK to your chosen output directory:
+//!
+//! ```shell
+//! docker run --rm -v output_path:/output ghcr.io/efforg/apkeep:stable -a com.instagram.android
+//! /output
+//! ```
 //!
 //! # Specify a CSV file or individual app ID
 //!


### PR DESCRIPTION
Hey there,

I don't know if you are interested in this, but I wanted this for myself (Docker is just much easier to deploy on my systems generally) so I set this up to automatically build Docker images on commit and release and I figured I might as well share it :)

The `edge` tag for "latest commit in mater" was chosen because the Alpine project also chooses this, and many people (incorrectly) assume the `latest` tag under Docker to be somewhat stable.

This script will build a Docker image from the source code on the latest commit and tag it with `edge`. If it is a release, it will also tag it with `latest` and the release tag name. If the release is not marked as prerelease on GitHub, it will also be tagged `stable`. All three options have been tested to ensure they only publish the expected tags. See [edge](https://github.com/TheLastProject/apkeep/actions/runs/1705358187), [latest](https://github.com/TheLastProject/apkeep/actions/runs/1705419167) and [stable](https://github.com/TheLastProject/apkeep/actions/runs/1705433670).