### PR TITLE
Update the Google Play usage docs with a note about region-locked apps.

### DIFF
--- a/USAGE-google-play.md
+++ b/USAGE-google-play.md
@@ -34,6 +34,12 @@ Likewise, a separate timezone or locale can also be specified:
 apkeep -a com.instagram.android -d google-play -o device=ad_g3_pro,locale=es_MX -e 'someone@gmail.com' -t some_aas_token .
 ```
 
+Note that if the app you're downloading is region-locked and not available in your region, the locale and timezone changes alone will not let apkeep download it. 
+In that case the download will fail with a `Invalid app response` error. 
+To download a region-locked app you first need to bind it to your account by downloading it with an IP address from a region it's available in.
+After the first download, you can download the app from any region.
+
+
 This option attempts to download a split APK if available, and falls back to the full APK:
 
 ```shell
@@ -44,6 +50,7 @@ A full list of options:
 
 * `device`: specify a device profile as described above
 * `locale`: specify a locale
+* `timezone`: specify a timezone 
 * `split_apk`: when set to `1` or `true`, attempts to download a [split APK](https://developer.android.com/studio/build/configure-apk-splits)
 * `include_additional_files`: when set to `1` or `true`, attempts to download any [additional `obb` expansion files](https://developer.android.com/google/play/expansion-files) for the app
 


### PR DESCRIPTION
Added a clarification that a custom locale will not allow you to download apps that are region locked.
Spent like an hour wondering why my app isn't downloading due to assuming it works based on locale not on IP.