### PR TITLE
added flag to download dexmetadata

### DIFF
--- a/USAGE-google-play.md
+++ b/USAGE-google-play.md
@@ -52,6 +52,7 @@ A full list of options:
 * `locale`: specify a locale
 * `timezone`: specify a timezone 
 * `split_apk`: when set to `1` or `true`, attempts to download a [split APK](https://developer.android.com/studio/build/configure-apk-splits)
+* `include_dex_metadata`: when set to `1` or `true`, attempts to download the DexMetadata (dm) file for an app, which contains the apps' cloud profile
 * `include_additional_files`: when set to `1` or `true`, attempts to download any [additional `obb` expansion files](https://developer.android.com/google/play/expansion-files) for the app
 
 If you prefer not to provide your credentials on the command line, you can specify them in a config file named `apkeep.ini`.  This config file may have to be created, and must be located in the user config directory under the subpath `apkeep`.  Usually on Linux systems this will be `~/.config/apkeep/apkeep.ini`.  In this file specify your email and/or AAS token:

--- a/src/download_sources/google_play.rs
+++ b/src/download_sources/google_play.rs
@@ -29,6 +29,10 @@ pub async fn download_apps(
         Some(val) if val == "1" || val.to_lowercase() == "true" => true,
         _ => false,
     };
+    let include_dex_metadata = match options.remove("include_dex_metadata") {
+        Some(val) if val == "1" || val.to_lowercase() == "true" => true,
+        _ => false,
+    };
     let mut gpa = Gpapi::new(device, email);
 
     if let Some(locale) = options.remove("locale") {
@@ -85,7 +89,7 @@ pub async fn download_apps(
                     if sleep_duration > 0 {
                         sleep(TokioDuration::from_millis(sleep_duration)).await;
                     }
-                    match gpa.download(&app_id, None, split_apk, include_additional_files, Path::new(outpath), Some(&progress_wrapper(mp_dl1))).await {
+                    match gpa.download(&app_id, None, split_apk, include_dex_metadata, include_additional_files, Path::new(outpath), Some(&progress_wrapper(mp_dl1))).await {
                         Ok(_) => mp_log.suspend(|| println!("{} downloaded successfully!", app_id)),
                         Err(err) if matches!(err.kind(), GpapiErrorKind::FileExists) => {
                             mp_log.println(format!("File already exists for {}. Skipping...", app_id)).unwrap();
@@ -101,11 +105,11 @@ pub async fn download_apps(
                         }
                         Err(_) => {
                             mp_log.println(format!("An error has occurred attempting to download {}.  Retry #1...", app_id)).unwrap();
-                            match gpa.download(&app_id, None, split_apk, include_additional_files, Path::new(outpath), Some(&progress_wrapper(mp_dl2))).await {
+                            match gpa.download(&app_id, None, split_apk, include_dex_metadata, include_additional_files, Path::new(outpath), Some(&progress_wrapper(mp_dl2))).await {
                                 Ok(_) => mp_log.suspend(|| println!("{} downloaded successfully!", app_id)),
                                 Err(_) => {
                                     mp_log.println(format!("An error has occurred attempting to download {}.  Retry #2...", app_id)).unwrap();
-                                    match gpa.download(&app_id, None, split_apk, include_additional_files, Path::new(outpath), Some(&progress_wrapper(mp_dl3))).await {
+                                    match gpa.download(&app_id, None, split_apk, include_dex_metadata, include_additional_files, Path::new(outpath), Some(&progress_wrapper(mp_dl3))).await {
                                         Ok(_) => mp_log.suspend(|| println!("{} downloaded successfully!", app_id)),
                                         Err(_) => {
                                             mp_log.println(format!("An error has occurred attempting to download {}. Skipping...", app_id)).unwrap();


### PR DESCRIPTION
This allows apkeep to download dex metadata (dm) files, which contain cloud profiles. 

This depends on a [patch of rs-google-play](https://github.com/EFForg/rs-google-play/pull/24) and doesn't have the necessary version bumps yet.