### PR TITLE
Add support for Google auth token as alternative to aas-token

### DIFF
--- a/USAGE
+++ b/USAGE
@@ -28,6 +28,8 @@ Options:
           Google account email address (required if download source is Google Play)
   -t, --aas-token <google_aas_token>
           Google aas token  (required if download source is Google Play)
+      --auth-token <google_auth_token>
+          Google auth token (alternative to aas-token, e.g., from Aurora dispenser)
       --accept-tos
           Accept Google Play Terms of Service
   -s, --sleep-duration <sleep_duration>

--- a/USAGE-google-play.md
+++ b/USAGE-google-play.md
@@ -1,4 +1,8 @@
-To download directly from the Google Play Store, first you'll have to obtain an OAuth token by visiting the Google [embedded setup page](https://accounts.google.com/EmbeddedSetup) and:
+To download directly from the Google Play Store, you have two authentication options:
+
+## Option 1: Using OAuth Token (recommended for personal accounts)
+
+First, obtain an OAuth token by visiting the Google [embedded setup page](https://accounts.google.com/EmbeddedSetup) and:
 
 - Opening the browser debugging console on `Network` tab
 - Logging in
@@ -20,7 +24,19 @@ An AAS token should be printed. You can use this to download an app:
 apkeep -a com.instagram.android -d google-play -e 'someone@gmail.com' -t some_aas_token .
 ```
 
-This will use a default device configuration of `px_9a`, a timezone of `UTC`, and a locale of `en_US`.  To specify a different device profile, use the `-o` option:
+## Option 2: Using AUTH Token (for token dispensers)
+
+If you have an AUTH token from a token dispenser (e.g., Aurora Store's dispenser), you can use it directly with the `--auth-token` flag:
+
+```shell
+apkeep -a com.instagram.android -d google-play -e 'dispenser_email@gmail.com' --auth-token 'ya29.a0...' --accept-tos .
+```
+
+AUTH tokens typically start with `ya29.`. The `--accept-tos` flag is recommended for first-time use with a new account to automatically accept Google Play's Terms of Service.
+
+## Device Configuration
+
+Both options will use a default device configuration of `px_9a`, a timezone of `UTC`, and a locale of `en_US`. To specify a different device profile, use the `-o` option:
 
 ```shell
 apkeep -a com.instagram.android -d google-play -o device=ad_g3_pro -e 'someone@gmail.com' -t some_aas_token .
@@ -55,12 +71,14 @@ A full list of options:
 * `include_dex_metadata`: when set to `1` or `true`, attempts to download the DexMetadata (dm) file for an app, which contains the apps' cloud profile
 * `include_additional_files`: when set to `1` or `true`, attempts to download any [additional `obb` expansion files](https://developer.android.com/google/play/expansion-files) for the app
 
-If you prefer not to provide your credentials on the command line, you can specify them in a config file named `apkeep.ini`.  This config file may have to be created, and must be located in the user config directory under the subpath `apkeep`.  Usually on Linux systems this will be `~/.config/apkeep/apkeep.ini`.  In this file specify your email and/or AAS token:
+If you prefer not to provide your credentials on the command line, you can specify them in a config file named `apkeep.ini`. This config file may have to be created, and must be located in the user config directory under the subpath `apkeep`. Usually on Linux systems this will be `~/.config/apkeep/apkeep.ini`. In this file specify your email and token:
 
 ```ini
 [google]
 email = someone@gmail.com
 aas_token = some_aas_token
+# OR use auth_token instead of aas_token:
+# auth_token = ya29.a0...
 ```
 
 Optionally, the path to this `ini` file can be specified:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -123,6 +123,14 @@ pub fn app() -> Command {
                 .short('t')
                 .long("aas-token")
                 .action(ArgAction::Set)
+                .conflicts_with("google_auth_token")
+        )
+        .arg(
+            Arg::new("google_auth_token")
+                .help("Google auth token (alternative to aas-token, e.g., from Aurora dispenser)")
+                .long("auth-token")
+                .action(ArgAction::Set)
+                .conflicts_with("google_aas_token")
         )
         .arg(
             Arg::new("google_accept_tos")

--- a/src/download_sources/google_play.rs
+++ b/src/download_sources/google_play.rs
@@ -15,7 +15,8 @@ pub async fn download_apps(
     parallel: usize,
     sleep_duration: u64,
     email: &str,
-    aas_token: &str,
+    aas_token: Option<&str>,
+    auth_token: Option<&str>,
     outpath: &Path,
     accept_tos: bool,
     mut options: HashMap<&str, &str>,
@@ -42,21 +43,25 @@ pub async fn download_apps(
         gpa.set_timezone(timezone);
     }
 
-    gpa.set_aas_token(aas_token);
+    // Set the appropriate token type
+    if let Some(aas) = aas_token {
+        gpa.set_aas_token(aas);
+    } else if let Some(auth) = auth_token {
+        gpa.set_auth_token(auth);
+    } else {
+        eprintln!("Either AAS token or AUTH token must be provided");
+        std::process::exit(1);
+    }
     if let Err(err) = gpa.login().await {
         match err.kind() {
             GpapiErrorKind::TermsOfService => {
                 if accept_tos {
                     match gpa.accept_tos().await {
                         Ok(_) => {
-                            if let Err(_) = gpa.login().await {
-                                eprintln!("Could not log in, even after accepting the Google Play Terms of Service");
-                                std::process::exit(1);
-                            }
                             println!("Google Play Terms of Service accepted.");
                         },
-                        _ => {
-                            eprintln!("Could not accept Google Play Terms of Service");
+                        Err(e) => {
+                            eprintln!("Could not accept Google Play Terms of Service: {}", e);
                             std::process::exit(1);
                         },
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -322,7 +322,8 @@ async fn main() {
                     ).await;
                 } else {
                     let mut aas_token = matches.get_one::<String>("google_aas_token").map(|v| v.to_string());
-                    let accept_tos = match matches.get_one::<bool>("list_versions") {
+                    let mut auth_token = matches.get_one::<String>("google_auth_token").map(|v| v.to_string());
+                    let accept_tos = match matches.get_one::<bool>("google_accept_tos") {
                         Some(true) => true,
                         _ => false,
                     };
@@ -339,13 +340,16 @@ async fn main() {
                         }
                     });
 
-                    if email.is_none() || aas_token.is_none() {
+                    if email.is_none() || (aas_token.is_none() && auth_token.is_none()) {
                         if let Ok(conf) = load_config(ini_file) {
                             if email.is_none() {
                                 email = conf.get("google", "email");
                             }
-                            if aas_token.is_none() {
+                            if aas_token.is_none() && auth_token.is_none() {
                                 aas_token = conf.get("google", "aas_token");
+                                if aas_token.is_none() {
+                                    auth_token = conf.get("google", "auth_token");
+                                }
                             }
                         }
                     }
@@ -358,12 +362,18 @@ async fn main() {
                         email = Some(prompt_email.trim().to_string());
                     }
 
-                    if aas_token.is_none() {
-                        let mut prompt_aas_token = String::new();
-                        print!("AAS Token: ");
+                    if aas_token.is_none() && auth_token.is_none() {
+                        let mut prompt_token = String::new();
+                        print!("AAS Token (or AUTH Token): ");
                         io::stdout().flush().unwrap();
-                        io::stdin().read_line(&mut prompt_aas_token).unwrap();
-                        aas_token = Some(prompt_aas_token.trim().to_string());
+                        io::stdin().read_line(&mut prompt_token).unwrap();
+                        let token = prompt_token.trim().to_string();
+                        // Heuristic: AUTH tokens typically start with "ya29."
+                        if token.starts_with("ya29.") {
+                            auth_token = Some(token);
+                        } else {
+                            aas_token = Some(token);
+                        }
                     }
 
                     google_play::download_apps(
@@ -371,7 +381,8 @@ async fn main() {
                         parallel,
                         sleep_duration,
                         &email.unwrap(),
-                        &aas_token.unwrap(),
+                        aas_token.as_deref(),
+                        auth_token.as_deref(),
                         &outpath.unwrap(),
                         accept_tos,
                         options,


### PR DESCRIPTION
Full disclosure: This change was done with an LLM and requires: https://github.com/EFForg/rs-google-play/pull/26
## Summary

This PR adds support for AUTH tokens (e.g., from Aurora Store's token dispenser), allowing users to authenticate without going through the OAuth → AAS token flow.

## Motivation

Aurora Store's token dispenser provides AUTH tokens (starting with `ya29.`) for anonymous access to Google Play. Previously, apkeep only supported AAS tokens, making it incompatible with these dispensers. This PR bridges that gap.

## Changes

### New CLI Option

- **`--auth-token <TOKEN>`**: Accepts an AUTH token directly (mutually exclusive with `-t`/`--aas-token`)

### Modified Files

1. **`src/cli.rs`**
   - Added `google_auth_token` argument with `--auth-token` flag
   - Set up mutual exclusivity with `--aas-token`

2. **`src/main.rs`**
   - Handle both `aas_token` and `auth_token` from CLI and config file
   - Auto-detect token type when prompting (tokens starting with `ya29.` are treated as AUTH)
   - Fixed bug: `accept_tos` was reading from wrong CLI argument (`list_versions` instead of `google_accept_tos`)

3. **`src/download_sources/google_play.rs`**
   - Updated `download_apps()` signature to accept both token types as `Option<&str>`
   - Call appropriate gpapi method based on token type provided
   - Simplified TOS acceptance flow (removed redundant `login()` call after `accept_tos()`)

4. **`USAGE-google-play.md`**
   - Added documentation for AUTH token usage
   - Added config file example with `auth_token` option

### Config File Support

Users can now specify `auth_token` in their config file:

```ini
[google]
email = someone@gmail.com
auth_token = ya29.a0...
```

## Usage Example

```shell
# Get AUTH token from Aurora dispenser
python3 get_dispenser_token.py --properties gplayapi_px_9a.properties

# Use with apkeep
apkeep -a com.instagram.android -d google-play \
  -e 'dispenser_email@gmail.com' \
  --auth-token 'ya29.a0...' \
  --accept-tos .
```

## Bug Fixes

1. **Fixed `--accept-tos` flag not working**: The flag was reading from the wrong CLI argument (`list_versions` instead of `google_accept_tos`)

## Dependencies

This PR requires the corresponding changes to the `gpapi` crate that add `set_auth_token()` support.

**Before submitting this PR:**
1. First submit and merge the gpapi PR to `EFForg/rs-google-play`
2. Publish the updated gpapi crate (or wait for maintainer to publish)
3. Update `Cargo.toml` to use the new gpapi version:
   ```toml
   gpapi = "7"  # or whatever version includes set_auth_token()
   ```
4. Then submit this PR

## Backward Compatibility

✅ **Fully backward compatible**

- Existing `-t`/`--aas-token` flow remains unchanged
- Config file `aas_token` option still works
- All existing functionality preserved

## Testing

- Tested with AUTH tokens from Aurora Store's token dispenser
- Verified TOS acceptance works correctly
- Confirmed APK downloads succeed
- Verified backward compatibility with AAS tokens