### PR TITLE
Add phone-farm orchestrator for Google Play crawling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,11 @@
 *.swp
 /target
+
+# farm: real credentials and generated state (never commit)
+accounts.csv
+farm/accounts.csv
+farm/queue.db
+farm/logs/
+farm/out/
+farm/devices/
+farm/__pycache__/

--- a/farm/README.md
+++ b/farm/README.md
@@ -1,0 +1,133 @@
+# Phone-farm downloader for apkeep
+
+Downloads a list of apps from Google Play across a pool of Google accounts (one per
+phone). It's a driver over the `apkeep` binary with a SQLite queue, so it resumes
+after interruptions and, if an account gets rate-limited or banned, hands its
+remaining apps to the other accounts automatically.
+
+Stdlib Python only — no `pip install`.
+
+## 1. Build apkeep
+
+```sh
+cargo build --release        # produces ../target/release/apkeep
+```
+
+## 2. Prepare accounts
+
+Create `accounts.csv` from the example:
+
+```sh
+cp accounts.csv.example accounts.csv
+```
+
+One row per phone/account:
+
+```
+email,token,token_type,device_properties_path,locale
+someone@gmail.com,AAS_TOKEN_HERE,aas,,us
+```
+
+- **token** — the account's AAS token. Get it via:
+  ```sh
+  ../target/release/apkeep -e someone@gmail.com --oauth-token oauth2_4/<value>
+  ```
+  where `<value>` is the `oauth_token` cookie (starts `oauth2_4/`) from the network
+  tab of `https://accounts.google.com/EmbeddedSetup` after signing in. apkeep prints
+  the AAS token. (Full walkthrough: `../USAGE-google-play.md`.)
+- **token_type** — `aas` (default) or `auth` for an AUTH token (`ya29.…`).
+- **device_properties_path** — leave blank to use the default device (Pixel 9a), or
+  see section 3.
+- **locale** — e.g. `us`, `fr`.
+
+Use **disposable** accounts — Google may terminate accounts used this way.
+
+## 3. Device profile (optional)
+
+This decides which APK variant Google serves (CPU/ABI, screen size, Android
+version). Match it to the device you'll install/test on, or some splits may not
+install. Skip this section to use the default (Pixel 9a).
+
+**Option A — pick a built-in profile.** Find your test device's model
+(Settings → About phone), match it to a `[name]` in
+https://github.com/EFForg/rs-google-play/blob/master/gpapi/device.properties,
+and pass it to a run with `--device <name>` (leave the CSV column blank).
+
+**Option B — export the real device.** On the test device install **Aurora Store**
+(https://auroraoss.com), open **Settings → Spoof Manager → Device**, and use
+**export/share** to save its `.properties` file. Copy it to `farm/devices/mydevice.properties`
+and put that path in the `device_properties_path` column.
+
+## 4. Verify accounts
+
+Check every account can log in (no downloads):
+
+```sh
+python3 farm.py --accounts accounts.csv --apkeep ../target/release/apkeep --check
+```
+
+Prints `OK`/`BAD` per account and exits non-zero if any are bad. Fix any `BAD`
+token before running.
+
+## 5. Run
+
+`apps.csv` is one package name per line (or a CSV — pick the column with `--field`).
+
+```sh
+mkdir -p out
+python3 farm.py \
+  --apps apps.csv \
+  --accounts accounts.csv \
+  --outdir out \
+  --apkeep ../target/release/apkeep \
+  --batch-size 50 --parallel 4 --sleep 1000 --accept-tos
+```
+
+Stop any time with Ctrl-C (workers finish their current batch). Re-run the same
+command to resume — finished apps are skipped, interrupted ones are picked back up.
+
+### Options
+
+| flag | default | meaning |
+|------|---------|---------|
+| `--apps` | — | package list (CSV/text), one per line |
+| `--accounts` | — | accounts.csv |
+| `--outdir` | — | where APKs are written |
+| `--apkeep` | `apkeep` | path to the apkeep binary |
+| `--field` | 1 | app-id column in `--apps` |
+| `--batch-size` | 50 | apps per account per apkeep call |
+| `--parallel` | 4 | concurrent downloads within one account |
+| `--sleep` | 1000 | ms between apps (rate control) |
+| `--device` | — | built-in device profile name (Option A) |
+| `--max-attempts` | 3 | tries per app before it's marked `failed` |
+| `--max-fails` | 3 | bad batches before an account cools down |
+| `--cooldowns` | 1 | cooldowns before an account is disabled |
+| `--cooldown` | 600 | cooldown seconds |
+| `--accept-tos` | off | accept Google Play ToS on first use |
+| `--no-split-apk` | off | download full APK instead of split APKs |
+
+Effective download rate ≈ `accounts × parallel`, paced by `--sleep`. If you see
+retries or errors in the logs, raise `--sleep` or lower `--parallel`.
+
+## Progress & results
+
+```sh
+sqlite3 queue.db "SELECT status, COUNT(*) FROM apps GROUP BY status"   # overview
+sqlite3 queue.db "SELECT pkg FROM apps WHERE status='failed'"          # gave up on these
+```
+
+- `logs/<email>.log` — per-account apkeep output.
+- Watch for throttling: `grep -iE 'retry|error' logs/*.log`.
+
+## Notes
+
+- **Disk**: apps are large. Thousands of apps can be hundreds of GB — make sure
+  `--outdir` has room.
+- **Region-locked apps** must be downloaded once from an allowed-region IP before
+  they work elsewhere; otherwise they fail with `Invalid app response`.
+
+## Test the tool itself
+
+```sh
+python3 test_farm.py
+```

--- a/farm/accounts.csv.example
+++ b/farm/accounts.csv.example
@@ -1,0 +1,6 @@
+email,token,token_type,device_properties_path,locale
+# One row per phone/account. token_type is "aas" (default) or "auth".
+# device_properties_path may be blank to use apkeep's built-in default device.
+phone1@gmail.com,ya29.aas_token_here,aas,./devices/phone1.properties,us
+phone2@gmail.com,ya29.a0Ae...auth_token_here,auth,./devices/phone2.properties,at
+phone3@gmail.com,another_aas_token,aas,,us

--- a/farm/farm.py
+++ b/farm/farm.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""Phone-farm orchestrator for apkeep Google Play crawling.
+
+Drives N apkeep subprocesses (one worker per Google account) over a crash-safe
+SQLite work queue. Durable resume + automatic redistribution of a banned
+account's apps. Stdlib only.
+
+See README.md in this directory for setup and usage.
+"""
+import argparse
+import csv
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+# ---- pure queue logic (unit-tested in test_farm.py) -------------------------
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS apps (
+    pkg TEXT PRIMARY KEY,
+    status TEXT NOT NULL DEFAULT 'pending',  -- pending | claimed | done | failed
+    attempts INTEGER NOT NULL DEFAULT 0,
+    account TEXT,
+    updated REAL NOT NULL DEFAULT 0
+);
+CREATE TABLE IF NOT EXISTS accounts (
+    email TEXT PRIMARY KEY,
+    status TEXT NOT NULL DEFAULT 'active',   -- active | cooldown | disabled
+    fails INTEGER NOT NULL DEFAULT 0
+);
+"""
+
+
+def init_db(conn):
+    conn.executescript(SCHEMA)
+    conn.commit()
+
+
+def seed_apps(conn, pkgs, now):
+    conn.executemany(
+        "INSERT OR IGNORE INTO apps(pkg, status, updated) VALUES (?, 'pending', ?)",
+        [(p, now) for p in pkgs],
+    )
+    conn.commit()
+
+
+def seed_accounts(conn, emails):
+    conn.executemany(
+        "INSERT OR IGNORE INTO accounts(email, status, fails) VALUES (?, 'active', 0)",
+        [(e,) for e in emails],
+    )
+    conn.commit()
+
+
+def recover(conn, now):
+    """Revert rows left 'claimed' by a crashed run back to 'pending'. Returns count."""
+    cur = conn.execute("SELECT COUNT(*) FROM apps WHERE status='claimed'")
+    n = cur.fetchone()[0]
+    conn.execute(
+        "UPDATE apps SET status='pending', account=NULL, updated=? WHERE status='claimed'",
+        (now,),
+    )
+    conn.commit()
+    return n
+
+
+def claim_batch(conn, account, n, now):
+    """Atomically claim up to n pending pkgs for `account`. Returns list of pkgs."""
+    rows = conn.execute(
+        "SELECT pkg FROM apps WHERE status='pending' ORDER BY attempts, pkg LIMIT ?",
+        (n,),
+    ).fetchall()
+    pkgs = [r[0] for r in rows]
+    if pkgs:
+        qs = ",".join("?" * len(pkgs))
+        conn.execute(
+            f"UPDATE apps SET status='claimed', account=?, updated=? WHERE pkg IN ({qs})",
+            [account, now, *pkgs],
+        )
+        conn.commit()
+    return pkgs
+
+
+def record_results(conn, successes, failures, max_attempts, now):
+    """Mark successes done; bump failures back to pending (or 'failed' at max_attempts)."""
+    if successes:
+        qs = ",".join("?" * len(successes))
+        conn.execute(
+            f"UPDATE apps SET status='done', updated=? WHERE pkg IN ({qs})",
+            [now, *successes],
+        )
+    for pkg in failures:
+        conn.execute(
+            """UPDATE apps SET attempts=attempts+1, account=NULL, updated=?,
+               status=CASE WHEN attempts+1 >= ? THEN 'failed' ELSE 'pending' END
+               WHERE pkg=?""",
+            (now, max_attempts, pkg),
+        )
+    conn.commit()
+
+
+def remaining(conn):
+    """Count apps still workable (pending or claimed)."""
+    return conn.execute(
+        "SELECT COUNT(*) FROM apps WHERE status IN ('pending','claimed')"
+    ).fetchone()[0]
+
+
+def release_claimed(conn, account, now):
+    """Return an account's in-flight claimed rows to the pool (crash/exit cleanup)."""
+    conn.execute(
+        "UPDATE apps SET status='pending', account=NULL, updated=? WHERE status='claimed' AND account=?",
+        (now, account),
+    )
+    conn.commit()
+
+
+def set_account(conn, email, status, fails):
+    conn.execute(
+        "UPDATE accounts SET status=?, fails=? WHERE email=?", (status, fails, email)
+    )
+    conn.commit()
+
+
+def summary(conn):
+    return dict(conn.execute("SELECT status, COUNT(*) FROM apps GROUP BY status").fetchall())
+
+
+# ---- apkeep invocation ------------------------------------------------------
+
+
+def build_cmd(apkeep, account, batch_csv, outdir, options, parallel, sleep, accept_tos):
+    opts = list(options)
+    if account["locale"]:
+        opts.append(f"locale={account['locale']}")
+    if account["device_properties_path"]:
+        # a custom file must be paired with device=default (see USAGE-google-play.md)
+        opts.append("device=default")
+        opts.append(f"device_properties_file={account['device_properties_path']}")
+    cmd = [
+        apkeep, "-c", batch_csv, "-d", "google-play",
+        "-e", account["email"],
+        "-r", str(parallel), "-s", str(sleep),
+    ]
+    if account["token_type"] == "auth":
+        cmd += ["--auth-token", account["token"]]
+    else:
+        cmd += ["-t", account["token"]]
+    if accept_tos:
+        cmd += ["--accept-tos"]
+    cmd += ["-o", ",".join(opts), outdir]
+    return cmd
+
+
+def check_accounts(cfg, accounts):
+    """Probe each account's login without downloading. Returns list of (email, ok, detail)."""
+    import concurrent.futures
+
+    bogus = "com.apkeep.farm.login.probe"  # nonexistent app: login runs, download is skipped
+    tmp = tempfile.mkdtemp(prefix="apkeep-check-")
+
+    def probe(a):
+        cmd = [cfg.apkeep, "-d", "google-play", "-e", a["email"], "-r", "1", "-s", "0", "--accept-tos"]
+        cmd += ["--auth-token", a["token"]] if a["token_type"] == "auth" else ["-t", a["token"]]
+        opts = []
+        if a["locale"]:
+            opts.append(f"locale={a['locale']}")
+        if a["device_properties_path"]:
+            opts.append("device=default")
+            opts.append(f"device_properties_file={a['device_properties_path']}")
+        if opts:
+            cmd += ["-o", ",".join(opts)]
+        cmd += ["-a", bogus, tmp]
+        try:
+            r = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+            out = (r.stdout + r.stderr).lower()
+        except subprocess.TimeoutExpired:
+            return a["email"], False, "timed out"
+        if "could not log in" in out or "could not accept" in out:
+            return a["email"], False, "login rejected (bad/expired token)"
+        # login succeeded; the probe app is (correctly) reported invalid/skipped
+        return a["email"], True, "ok"
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=min(8, len(accounts))) as ex:
+        return list(ex.map(probe, accounts))
+
+
+def produced(outdir, pkg):
+    """True if apkeep produced output for pkg (single apk or split dir)."""
+    apk = Path(outdir) / f"{pkg}.apk"
+    if apk.is_file() and apk.stat().st_size > 0:
+        return True
+    d = Path(outdir) / pkg
+    if d.is_dir() and any(d.iterdir()):
+        return True
+    # gpapi may suffix versioned names; fall back to a prefix glob
+    return any(Path(outdir).glob(f"{pkg}*"))
+
+
+# ---- worker -----------------------------------------------------------------
+
+
+def worker(name, account, conn, lock, cfg, stop):
+    email = account["email"]
+    cooldowns_used = 0
+    try:
+        _worker_loop(name, account, conn, lock, cfg, stop, cooldowns_used)
+    except Exception as e:  # disk full, DB error, etc. -- don't strand this account's work
+        print(f"[{name}] worker crashed: {e}; releasing its claimed apps")
+    finally:
+        try:
+            with lock:
+                release_claimed(conn, email, time.time())
+        except Exception:
+            pass  # next run's recover() will reclaim if this also fails
+
+
+def _worker_loop(name, account, conn, lock, cfg, stop, cooldowns_used):
+    email = account["email"]
+    while not stop.is_set():
+        with lock:
+            batch = claim_batch(conn, email, cfg.batch_size, time.time())
+        if not batch:
+            with lock:
+                left = remaining(conn)
+            if left == 0:
+                return  # queue drained
+            time.sleep(5)  # others still hold claimed rows; wait for possible release
+            continue
+
+        with tempfile.NamedTemporaryFile("w", suffix=".csv", delete=False) as f:
+            f.write("\n".join(batch) + "\n")
+            batch_csv = f.name
+        try:
+            cmd = build_cmd(cfg.apkeep, account, batch_csv, cfg.outdir,
+                            cfg.options, cfg.parallel, cfg.sleep, cfg.accept_tos)
+            log_path = Path(cfg.logdir) / f"{email}.log"
+            with open(log_path, "a") as lf:
+                lf.write(f"\n=== batch of {len(batch)} @ {time.strftime('%F %T')} ===\n")
+                rc = subprocess.run(cmd, stdout=lf, stderr=subprocess.STDOUT).returncode
+        finally:
+            os.unlink(batch_csv)
+
+        successes = [p for p in batch if produced(cfg.outdir, p)]
+        failures = [p for p in batch if p not in successes]
+        with lock:
+            record_results(conn, successes, failures, cfg.max_attempts, time.time())
+
+        # account health: rc!=0 (login death) or a batch that produced nothing = a strike
+        if rc != 0 or (batch and not successes):
+            account["fails"] += 1
+            print(f"[{name}] strike {account['fails']}/{cfg.max_fails} "
+                  f"(rc={rc}, {len(successes)}/{len(batch)} ok)")
+        else:
+            account["fails"] = 0
+
+        if account["fails"] >= cfg.max_fails:
+            if cooldowns_used < cfg.cooldowns:
+                cooldowns_used += 1
+                account["fails"] = 0
+                with lock:
+                    set_account(conn, email, "cooldown", 0)
+                print(f"[{name}] cooldown {cooldowns_used}/{cfg.cooldowns} "
+                      f"for {cfg.cooldown}s")
+                if stop.wait(cfg.cooldown):
+                    return
+                with lock:
+                    set_account(conn, email, "active", 0)
+            else:
+                with lock:
+                    set_account(conn, email, "disabled", account["fails"])
+                print(f"[{name}] DISABLED after repeated failures; "
+                      f"its apps return to the queue for other accounts")
+                return
+
+
+# ---- setup ------------------------------------------------------------------
+
+
+def read_accounts(path):
+    accounts = []
+    with open(path, newline="") as f:
+        for row in csv.DictReader(f):
+            if not row.get("email", "").strip() or row["email"].lstrip().startswith("#"):
+                continue
+            accounts.append({
+                "email": row["email"].strip(),
+                "token": row["token"].strip(),
+                "token_type": (row.get("token_type") or "aas").strip().lower(),
+                "device_properties_path": (row.get("device_properties_path") or "").strip(),
+                "locale": (row.get("locale") or "").strip(),
+                "fails": 0,
+            })
+    return accounts
+
+
+def read_pkgs(path, field):
+    pkgs = []
+    with open(path, newline="") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            cols = line.split(",")
+            if field - 1 < len(cols):
+                pkg = cols[field - 1].strip()
+                if pkg:
+                    pkgs.append(pkg)
+    return pkgs
+
+
+def main(argv=None):
+    import sqlite3
+
+    p = argparse.ArgumentParser(description="apkeep phone-farm orchestrator")
+    p.add_argument("--apps", help="CSV/text of package names (not needed with --check)")
+    p.add_argument("--accounts", required=True, help="accounts.csv (see .example)")
+    p.add_argument("--outdir", help="download output directory (not needed with --check)")
+    p.add_argument("--check", action="store_true",
+                   help="probe every account's login and report valid/invalid, then exit")
+    p.add_argument("--db", default="queue.db", help="SQLite queue file")
+    p.add_argument("--logdir", default="logs", help="per-account apkeep logs")
+    p.add_argument("--apkeep", default="apkeep", help="path to apkeep binary")
+    p.add_argument("--field", type=int, default=1, help="1-based app-id column in --apps")
+    p.add_argument("--batch-size", type=int, default=50)
+    p.add_argument("--parallel", type=int, default=4, help="apkeep -r (in-flight per account)")
+    p.add_argument("--device", help="built-in device profile name (e.g. px_9a); overrides default")
+    p.add_argument("--sleep", type=int, default=1000, help="apkeep -s ms between apps")
+    p.add_argument("--max-attempts", type=int, default=3, help="per-app tries before 'failed'")
+    p.add_argument("--max-fails", type=int, default=3, help="consecutive bad batches before cooldown")
+    p.add_argument("--cooldowns", type=int, default=1, help="cooldowns before an account is disabled")
+    p.add_argument("--cooldown", type=int, default=600, help="cooldown seconds")
+    p.add_argument("--accept-tos", action="store_true")
+    p.add_argument("--split-apk", action="store_true", default=True)
+    p.add_argument("--no-split-apk", dest="split_apk", action="store_false")
+    p.add_argument("--additional-files", action="store_true", default=True,
+                   help="include OBB expansion files")
+    p.add_argument("--dex-metadata", action="store_true", help="include .dm cloud profiles")
+    cfg = p.parse_args(argv)
+
+    accounts = read_accounts(cfg.accounts)
+    if not accounts:
+        sys.exit("no accounts found")
+
+    if cfg.check:
+        print(f"Checking {len(accounts)} accounts...")
+        results = check_accounts(cfg, accounts)
+        bad = 0
+        for email, ok, detail in results:
+            print(f"  {'OK   ' if ok else 'BAD  '} {email}  ({detail})")
+            bad += not ok
+        print(f"\n{len(results) - bad}/{len(results)} valid.")
+        sys.exit(1 if bad else 0)
+
+    if not cfg.apps or not cfg.outdir:
+        sys.exit("--apps and --outdir are required (unless using --check)")
+    if not Path(cfg.outdir).is_dir():
+        sys.exit(f"outdir is not a directory: {cfg.outdir}")
+    Path(cfg.logdir).mkdir(parents=True, exist_ok=True)
+
+    cfg.options = []
+    if cfg.device:  # per-account device_properties_path (Option B) takes precedence in build_cmd
+        cfg.options.append(f"device={cfg.device}")
+    if cfg.split_apk:
+        cfg.options.append("split_apk=1")
+    if cfg.additional_files:
+        cfg.options.append("include_additional_files=1")
+    if cfg.dex_metadata:
+        cfg.options.append("include_dex_metadata=1")
+
+    pkgs = read_pkgs(cfg.apps, cfg.field)
+    if not pkgs:
+        sys.exit("no packages found")
+
+    conn = sqlite3.connect(cfg.db, check_same_thread=False)
+    conn.execute("PRAGMA busy_timeout=5000")
+    init_db(conn)
+    now = time.time()
+    seed_apps(conn, pkgs, now)
+    seed_accounts(conn, [a["email"] for a in accounts])
+    reverted = recover(conn, now)
+    if reverted:
+        print(f"Recovered {reverted} claimed apps from a previous run -> pending")
+    # a fresh run re-activates accounts disabled last time (tokens may be refreshed)
+    conn.execute("UPDATE accounts SET status='active', fails=0")
+    conn.commit()
+
+    print(f"{len(pkgs)} apps seeded ({remaining(conn)} remaining), "
+          f"{len(accounts)} accounts. Starting workers...")
+
+    lock = threading.Lock()  # ponytail: one global DB lock; batch claims make contention negligible
+    stop = threading.Event()
+    threads = []
+    for i, acc in enumerate(accounts):
+        t = threading.Thread(target=worker, args=(f"w{i}:{acc['email']}", acc, conn, lock, cfg, stop))
+        t.start()
+        threads.append(t)
+    try:
+        while any(t.is_alive() for t in threads):
+            for t in threads:
+                t.join(timeout=1)
+    except KeyboardInterrupt:
+        print("\nInterrupted; signalling workers to stop after current batch...")
+        stop.set()
+        for t in threads:
+            t.join()
+
+    s = summary(conn)
+    print(f"\nDone. {s}")
+    if s.get("failed"):
+        print(f"{s['failed']} apps hit --max-attempts and are marked 'failed' "
+              f"(query the DB: SELECT pkg FROM apps WHERE status='failed').")
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/farm/test_farm.py
+++ b/farm/test_farm.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Self-check for farm.py queue logic. Run: python3 test_farm.py
+
+No apkeep, no network, no files -- exercises the SQLite queue invariants that
+make resume + redistribution correct: atomic claim, crash recovery, terminal
+failure at max_attempts, and release-back-to-pending (redistribution).
+"""
+import sqlite3
+import farm
+
+
+def fresh():
+    c = sqlite3.connect(":memory:")
+    farm.init_db(c)
+    return c
+
+
+def test_claim_is_atomic_and_disjoint():
+    c = fresh()
+    farm.seed_apps(c, ["a", "b", "c", "d"], now=0)
+    b1 = farm.claim_batch(c, "acct1", 2, now=1)
+    b2 = farm.claim_batch(c, "acct2", 2, now=1)
+    assert set(b1) | set(b2) == {"a", "b", "c", "d"}, (b1, b2)
+    assert set(b1).isdisjoint(b2), "same pkg claimed twice"
+    assert farm.claim_batch(c, "acct3", 2, now=1) == [], "nothing left to claim"
+
+
+def test_recover_reverts_claimed():
+    c = fresh()
+    farm.seed_apps(c, ["a", "b"], now=0)
+    farm.claim_batch(c, "acct1", 2, now=1)  # simulate a crash mid-batch
+    assert farm.remaining(c) == 2
+    n = farm.recover(c, now=2)
+    assert n == 2
+    # after recovery they're claimable again
+    assert set(farm.claim_batch(c, "acct2", 2, now=3)) == {"a", "b"}
+
+
+def test_success_and_redistribution():
+    c = fresh()
+    farm.seed_apps(c, ["a", "b"], now=0)
+    farm.claim_batch(c, "acct1", 2, now=1)
+    # a succeeded, b failed (acct1 got banned) -> b returns to the pool
+    farm.record_results(c, successes=["a"], failures=["b"], max_attempts=3, now=2)
+    assert farm.summary(c).get("done") == 1
+    # b is pending again -> another account picks it up (redistribution)
+    assert farm.claim_batch(c, "acct2", 5, now=3) == ["b"]
+
+
+def test_terminal_failure_at_max_attempts():
+    c = fresh()
+    farm.seed_apps(c, ["x"], now=0)
+    for i in range(3):  # max_attempts=3
+        farm.claim_batch(c, "acct", 1, now=i)
+        farm.record_results(c, successes=[], failures=["x"], max_attempts=3, now=i)
+    assert farm.summary(c).get("failed") == 1, "should be terminal after 3 attempts"
+    assert farm.claim_batch(c, "acct", 1, now=9) == [], "failed apps are not re-claimed"
+    assert farm.remaining(c) == 0
+
+
+def test_reseed_is_idempotent():
+    c = fresh()
+    farm.seed_apps(c, ["a", "b"], now=0)
+    farm.record_results(c, successes=["a"], failures=[], max_attempts=3, now=1)
+    farm.seed_apps(c, ["a", "b", "c"], now=2)  # re-run with an extended list
+    s = farm.summary(c)
+    assert s.get("done") == 1 and s.get("pending") == 2, s  # 'a' stays done, 'c' added
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+            print(f"ok  {name}")
+    print("all passed")


### PR DESCRIPTION
farm/farm.py drives N apkeep subprocesses (one per Google account) over a crash-safe SQLite queue: durable resume, per-account cooldown/disable on repeated failures, and automatic redistribution of a banned account's apps to the rest of the pool. --check probes account logins without downloading.

No changes to apkeep's core. Stdlib Python only. Real credentials and generated state are gitignored; accounts.csv.example is the template.