### PR TITLE
Surface Google Play download errors and exit non-zero on failure

### DIFF
--- a/src/download_sources/google_play.rs
+++ b/src/download_sources/google_play.rs
@@ -20,7 +20,7 @@ pub async fn download_apps(
     outpath: &Path,
     accept_tos: bool,
     mut options: HashMap<&str, &str>,
-) {
+) -> usize {
     let device = options.remove("device").unwrap_or("px_9a");
     let split_apk = match options.remove("split_apk") {
         Some(val) if val == "1" || val.to_lowercase() == "true" => true,
@@ -81,7 +81,7 @@ pub async fn download_apps(
 
     let mp = Rc::new(MultiProgress::new());
     let gpa = Rc::new(gpa);
-    futures_util::stream::iter(
+    let results = futures_util::stream::iter(
         apps.into_iter().map(|app| {
             let (app_id, app_version) = app;
             let gpa = Rc::clone(&gpa);
@@ -91,47 +91,62 @@ pub async fn download_apps(
             let mp_log = Rc::clone(&mp);
 
             async move {
-                if app_version.is_none() {
-                    mp_log.suspend(|| println!("Downloading {}...", app_id));
-                    if sleep_duration > 0 {
-                        sleep(TokioDuration::from_millis(sleep_duration)).await;
+                if let Some(app_version) = app_version {
+                    mp_log.suspend(|| eprintln!("Specific versions can not be downloaded from Google Play ({}@{}). Skipping...", app_id, app_version));
+                    return false;
+                }
+                mp_log.suspend(|| println!("Downloading {}...", app_id));
+                if sleep_duration > 0 {
+                    sleep(TokioDuration::from_millis(sleep_duration)).await;
+                }
+                match gpa.download(&app_id, None, split_apk, include_dex_metadata, include_additional_files, Path::new(outpath), Some(&progress_wrapper(mp_dl1))).await {
+                    Ok(_) => {
+                        mp_log.suspend(|| println!("{} downloaded successfully!", app_id));
+                        true
                     }
-                    match gpa.download(&app_id, None, split_apk, include_dex_metadata, include_additional_files, Path::new(outpath), Some(&progress_wrapper(mp_dl1))).await {
-                        Ok(_) => mp_log.suspend(|| println!("{} downloaded successfully!", app_id)),
-                        Err(err) if matches!(err.kind(), GpapiErrorKind::FileExists) => {
-                            mp_log.println(format!("File already exists for {}. Skipping...", app_id)).unwrap();
-                        }
-                        Err(err) if matches!(err.kind(), GpapiErrorKind::DirectoryExists) => {
-                            mp_log.println(format!("Split APK directory already exists for {}. Skipping...", app_id)).unwrap();
-                        }
-                        Err(err) if matches!(err.kind(), GpapiErrorKind::InvalidApp) => {
-                            mp_log.println(format!("Invalid app response for {}. Skipping...", app_id)).unwrap();
-                        }
-                        Err(err) if matches!(err.kind(), GpapiErrorKind::PermissionDenied) => {
-                            mp_log.println(format!("Permission denied when attempting to write file for {}. Skipping...", app_id)).unwrap();
-                        }
-                        Err(_) => {
-                            mp_log.println(format!("An error has occurred attempting to download {}.  Retry #1...", app_id)).unwrap();
-                            match gpa.download(&app_id, None, split_apk, include_dex_metadata, include_additional_files, Path::new(outpath), Some(&progress_wrapper(mp_dl2))).await {
-                                Ok(_) => mp_log.suspend(|| println!("{} downloaded successfully!", app_id)),
-                                Err(_) => {
-                                    mp_log.println(format!("An error has occurred attempting to download {}.  Retry #2...", app_id)).unwrap();
-                                    match gpa.download(&app_id, None, split_apk, include_dex_metadata, include_additional_files, Path::new(outpath), Some(&progress_wrapper(mp_dl3))).await {
-                                        Ok(_) => mp_log.suspend(|| println!("{} downloaded successfully!", app_id)),
-                                        Err(_) => {
-                                            mp_log.println(format!("An error has occurred attempting to download {}. Skipping...", app_id)).unwrap();
-                                        }
+                    Err(err) if matches!(err.kind(), GpapiErrorKind::FileExists) => {
+                        mp_log.suspend(|| eprintln!("File already exists for {}. Skipping...", app_id));
+                        true
+                    }
+                    Err(err) if matches!(err.kind(), GpapiErrorKind::DirectoryExists) => {
+                        mp_log.suspend(|| eprintln!("Split APK directory already exists for {}. Skipping...", app_id));
+                        true
+                    }
+                    Err(err) if matches!(err.kind(), GpapiErrorKind::InvalidApp) => {
+                        mp_log.suspend(|| eprintln!("Could not download {}. The app may be paid, nonexistent, restricted to certain accounts, unavailable in this region, or incompatible with the selected device. Skipping...", app_id));
+                        false
+                    }
+                    Err(err) if matches!(err.kind(), GpapiErrorKind::PermissionDenied) => {
+                        mp_log.suspend(|| eprintln!("Permission denied when attempting to write file for {}. Skipping...", app_id));
+                        false
+                    }
+                    Err(_) => {
+                        mp_log.suspend(|| eprintln!("An error has occurred attempting to download {}.  Retry #1...", app_id));
+                        match gpa.download(&app_id, None, split_apk, include_dex_metadata, include_additional_files, Path::new(outpath), Some(&progress_wrapper(mp_dl2))).await {
+                            Ok(_) => {
+                                mp_log.suspend(|| println!("{} downloaded successfully!", app_id));
+                                true
+                            }
+                            Err(_) => {
+                                mp_log.suspend(|| eprintln!("An error has occurred attempting to download {}.  Retry #2...", app_id));
+                                match gpa.download(&app_id, None, split_apk, include_dex_metadata, include_additional_files, Path::new(outpath), Some(&progress_wrapper(mp_dl3))).await {
+                                    Ok(_) => {
+                                        mp_log.suspend(|| println!("{} downloaded successfully!", app_id));
+                                        true
+                                    }
+                                    Err(_) => {
+                                        mp_log.suspend(|| eprintln!("An error has occurred attempting to download {}. Skipping...", app_id));
+                                        false
                                     }
                                 }
                             }
                         }
                     }
-                } else {
-                    mp_log.println(format!("Specific versions can not be downloaded from Google Play ({}@{}). Skipping...", app_id, app_version.unwrap())).unwrap();
                 }
             }
         })
-    ).buffer_unordered(parallel).collect::<Vec<()>>().await;
+    ).buffer_unordered(parallel).collect::<Vec<bool>>().await;
+    results.into_iter().filter(|&success| !success).count()
 }
 
 pub async fn request_aas_token(

--- a/src/main.rs
+++ b/src/main.rs
@@ -376,7 +376,7 @@ async fn main() {
                         }
                     }
 
-                    google_play::download_apps(
+                    let failures = google_play::download_apps(
                         list,
                         parallel,
                         sleep_duration,
@@ -388,6 +388,10 @@ async fn main() {
                         options,
                     )
                     .await;
+                    if failures > 0 {
+                        eprintln!("{} app(s) could not be downloaded.", failures);
+                        std::process::exit(1);
+                    }
                 }
             }
             DownloadSource::FDroid => {


### PR DESCRIPTION
## The problem

Every error message in the Google Play download path is silently discarded whenever `apkeep` runs without a TTY on stderr — piped, redirected, or under CI, cron, or Docker without `-t`. The process also exits `0` regardless, so a caller cannot detect the failure at all.

Reproducing, before this change:

```console
$ apkeep -a com.mojang.minecraftpe -d google-play -e ... -t ... ./out 2>&1
Downloading com.mojang.minecraftpe...
$ echo $?
0
```

No error, no file, no non-zero exit. The same happens for a nonexistent package, a permission error, or three exhausted retries.

## Why it happens

`MultiProgress::println()` writes through indicatif's draw target. `ProgressDrawTarget::term()` returns `Self::hidden()` when `stderr` is not a color-capable terminal, and a hidden target makes `width()` return `None`, which makes `draw()` return `Ok(())` before emitting anything. The message is dropped, and because the result is `Ok`, the `.unwrap()` at each call site does not panic either.

The two success messages were unaffected only because they go through `suspend()`, which is documented to run its closure even when the draw target is hidden. Every one of the seven error messages used `println()`.

## The change

- Route the error messages through `suspend()` + `eprintln!`. They now survive in non-interactive contexts and stay on stderr, which is where the draw target had been sending them all along.
- Propagate a failure count out of `download_apps()` and exit non-zero when it is greater than zero. An already-present file counts as success; unavailable apps, permission errors, exhausted retries, and version-pinned requests count as failures.
- Reword the `InvalidApp` message. The API returns that same error kind for several conditions that are indistinguishable in the response, so naming just one of them is misleading.

## After

| Case | Before | After |
|---|---|---|
| Paid / unavailable app | silent, exit 0 | message, exit 1 |
| Nonexistent package | silent, exit 0 | message, exit 1 |
| File already exists | silent, exit 0 | message, exit 0 |
| Version pinned (`app@1.2.3`) | silent, exit 0 | message, exit 1 |
| Successful download | works | works, exit 0 |

## Testing

Built with `cargo build --release` (no new warnings) and ran each row of the table above against a live Google Play account. Also confirmed that `2>/dev/null` leaves only the `Downloading ...` line on stdout, so the stdout/stderr split is intact, and that the progress bars still render normally in a terminal.

The same `println()` pattern exists in the APKPure, F-Droid, and Huawei App Gallery sources. This PR deliberately leaves those alone to stay reviewable; happy to follow up with the same treatment if you would like it in a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
